### PR TITLE
FernRP.Editor.asmdef的平台没有标记仅在Editor环境下可用，构建项目的时候会构建失败

### DIFF
--- a/Editor/FernRP.Editor.asmdef
+++ b/Editor/FernRP.Editor.asmdef
@@ -8,7 +8,9 @@
         "GUID:c579267770062bf448e75eb160330b7f",
         "GUID:11f9152636d0d7240aff7560db6b2a0d"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,


### PR DESCRIPTION
FernRP.Editor.asmdef的平台没有标记仅在Editor环境下可用，构建项目的时候会构建失败。我把FernRP.Editor.asmdef修改之后测试了一下，应该没问题了